### PR TITLE
chore: Comment out logging code on flush

### DIFF
--- a/lib/sidekiq/grouping/flusher.rb
+++ b/lib/sidekiq/grouping/flusher.rb
@@ -38,15 +38,16 @@ module Sidekiq
       def flush_concrete(batches)
         return if batches.empty?
 
-        names = batches.map do |batch|
-          "#{batch.worker_class} in #{batch.queue}"
-        end
-        unless Sidekiq::Grouping::Config.tests_env
-          Sidekiq::Grouping.logger.info(
-            "[Sidekiq::Grouping] Trying to flush batched queues: " \
-            "#{names.join(',')}"
-          )
-        end
+        # Comment out logging code since it can be noisy in production
+        # names = batches.map do |batch|
+        #   "#{batch.worker_class} in #{batch.queue}"
+        # end
+        # unless Sidekiq::Grouping::Config.tests_env
+        #   Sidekiq::Grouping.logger.info(
+        #     "[Sidekiq::Grouping] Trying to flush batched queues: " \
+        #     "#{names.join(',')}"
+        #   )
+        # end
         batches.each(&:flush)
       end
     end


### PR DESCRIPTION
As per title.

Comment out the logging code since it's very noisy on prod logs given out flush params.